### PR TITLE
Implement minimial flow support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+// @flow
 import {
   RPCToken,
   RPCHandlersToken,


### PR DESCRIPTION
While this won't provide full coverage, it will allow folks to use flow without ignoring fusion imports.

Fixes #71

Depends on migrating https://github.com/fusionjs/fusion-plugin-rpc/pull/98 and fusion-rpc-redux.