### PR TITLE
Make actions argument type optional in withRPCRedux

### DIFF
--- a/src/hoc.js
+++ b/src/hoc.js
@@ -32,7 +32,6 @@ export const withRPCReactor = (
   return withRPCRedux(rpcId, {
     actions: createRPCReactors(rpcId, reducers),
     propName,
-    rpcId,
     transformParams,
     mapStateToParams,
   });
@@ -47,7 +46,7 @@ export function withRPCRedux(
     mapStateToParams,
   }: {
     propName?: string,
-    actions: any,
+    actions?: any,
     transformParams?: (params: any) => any,
     mapStateToParams?: (state: any) => any,
   } = {}


### PR DESCRIPTION
The second argument of `withRPCRedux` required an `actions` property so if you wanted to use any of other properties like mapStateToProps you must pass null for actions to not fail a flow check.

Also remove an unnecessary `rpcId`