### PR TITLE
Use Anonymous as a fallback for HoC naming

### DIFF
--- a/src/hoc.js
+++ b/src/hoc.js
@@ -74,7 +74,7 @@ export function withRPCRedux(
         return React.createElement(Component, props);
       }
     }
-    const displayName = Component.displayName || Component.name;
+    const displayName = Component.displayName || Component.name || 'Anonymous';
     withRPCRedux.displayName = 'WithRPCRedux' + '(' + displayName + ')';
     withRPCRedux.contextTypes = {
       rpc: PropTypes.object.isRequired,


### PR DESCRIPTION
Follows what we've done in https://github.com/fusionjs/fusion-plugin-i18n-react/commit/9ee53a1da30a540fc120d6a0d389dd892da6c205

This is required to fix the latest flow-bin and release verification.