### PR TITLE
Pass own props to mapStateToProps

### DIFF
--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -106,6 +106,78 @@ test('browser plugin integration test withRPCRedux', async t => {
   t.end();
 });
 
+test('browser plugin integration test withRPCRedux and options', async t => {
+  setup();
+  const fetch = (url, options) => {
+    if (!options || !options.body || typeof options.body !== 'string') {
+      throw new Error(`Expected a string from options.body`);
+    }
+    const body: string = options.body;
+
+    t.equal(url, '/api/test', 'fetches to expected url');
+    t.deepLooseEqual(JSON.parse(body), {arg: 1, state: 2, prop: 3}, 'sends correct body');
+    t.equal(options.method, 'POST', 'makes POST request');
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          status: 'success',
+          data: {
+            a: 'b',
+          },
+        })
+      )
+    );
+  };
+
+  const expectedActions = [
+    {type: initActionPattern},
+    {type: /TEST_START/, payload: {arg: 1, state: 2, prop: 3}},
+    {type: /TEST_SUCCESS/, payload: {a: 'b'}},
+  ];
+  const store = createStore((state, action) => {
+    const fixture = expectedActions.shift();
+    t.ok(fixture.type.test(action.type), 'dispatches expected action type');
+    t.deepLooseEqual(
+      action.payload,
+      // $FlowFixMe
+      fixture.payload,
+      'dispatches expected action payload'
+    );
+    return {...state, ...action.payload};
+  }, {state: 2});
+
+  const Component = props => {
+    t.equal(typeof props.test, 'function', 'passes correct prop to component');
+    return React.createElement('span', null, 'hello world');
+  };
+
+  const mapStateToParams = (state, args, props) => {
+    return {...state, ...args, ...props};
+  };
+
+  const withTest = compose(
+    withRPCRedux('test', {mapStateToParams}),
+    connect(s => s),
+    prepared(props =>
+      props.a ? Promise.resolve() : props.test({arg: 1})
+    )
+  )(Component);
+
+  const element = React.createElement(
+    Provider,
+    {store},
+    React.createElement(withTest, {prop: 3})
+  );
+  const app = new App(element);
+  app.register(Plugin);
+  app.register(FetchToken, fetch);
+  await getSimulator(app).render('/');
+  t.equal(expectedActions.length, 0, 'dispatches all actions');
+
+  teardown();
+  t.end();
+});
+
 test('browser plugin integration test withRPCRedux - failure', async t => {
   setup();
   const fetch = (url, options) => {

--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -115,7 +115,11 @@ test('browser plugin integration test withRPCRedux and options', async t => {
     const body: string = options.body;
 
     t.equal(url, '/api/test', 'fetches to expected url');
-    t.deepLooseEqual(JSON.parse(body), {arg: 1, state: 2, prop: 3}, 'sends correct body');
+    t.deepLooseEqual(
+      JSON.parse(body),
+      {arg: 1, state: 2, prop: 3},
+      'sends correct body'
+    );
     t.equal(options.method, 'POST', 'makes POST request');
     return Promise.resolve(
       new Response(
@@ -134,17 +138,20 @@ test('browser plugin integration test withRPCRedux and options', async t => {
     {type: /TEST_START/, payload: {arg: 1, state: 2, prop: 3}},
     {type: /TEST_SUCCESS/, payload: {a: 'b'}},
   ];
-  const store = createStore((state, action) => {
-    const fixture = expectedActions.shift();
-    t.ok(fixture.type.test(action.type), 'dispatches expected action type');
-    t.deepLooseEqual(
-      action.payload,
-      // $FlowFixMe
-      fixture.payload,
-      'dispatches expected action payload'
-    );
-    return {...state, ...action.payload};
-  }, {state: 2});
+  const store = createStore(
+    (state, action) => {
+      const fixture = expectedActions.shift();
+      t.ok(fixture.type.test(action.type), 'dispatches expected action type');
+      t.deepLooseEqual(
+        action.payload,
+        // $FlowFixMe
+        fixture.payload,
+        'dispatches expected action payload'
+      );
+      return {...state, ...action.payload};
+    },
+    {state: 2}
+  );
 
   const Component = props => {
     t.equal(typeof props.test, 'function', 'passes correct prop to component');
@@ -158,9 +165,7 @@ test('browser plugin integration test withRPCRedux and options', async t => {
   const withTest = compose(
     withRPCRedux('test', {mapStateToParams}),
     connect(s => s),
-    prepared(props =>
-      props.a ? Promise.resolve() : props.test({arg: 1})
-    )
+    prepared(props => (props.a ? Promise.resolve() : props.test({arg: 1})))
   )(Component);
 
   const element = React.createElement(

--- a/src/hoc.js
+++ b/src/hoc.js
@@ -26,7 +26,7 @@ export const withRPCReactor = (
   }: {
     propName?: string,
     transformParams?: (params: any) => any,
-    mapStateToParams?: (state: any) => any,
+    mapStateToParams?: (state: any, args?: any, ownProps?: any) => any,
   } = {}
 ) => {
   return withRPCRedux(rpcId, {
@@ -49,7 +49,7 @@ export function withRPCRedux(
     propName?: string,
     actions?: any,
     transformParams?: (params: any) => any,
-    mapStateToParams?: (state: any) => any,
+    mapStateToParams?: (state: any, args?: any, ownProps?: any) => any,
   } = {}
 ): (React.ComponentType<*>) => React.ComponentType<*> {
   if (!propName) {
@@ -64,7 +64,7 @@ export function withRPCRedux(
           rpc,
           store,
           actions,
-          mapStateToParams,
+          mapStateToParams: (state, args) => mapStateToParams(state, args, this.props),
           transformParams,
         });
         const props = {

--- a/src/hoc.js
+++ b/src/hoc.js
@@ -59,12 +59,16 @@ export function withRPCRedux(
     class withRPCRedux extends React.Component<*, *> {
       render() {
         const {rpc, store} = this.context;
+        if (mapStateToParams) {
+          const mapState = mapStateToParams;
+          mapStateToParams = (state, args) => mapState(state, args, this.props);
+        }
         const handler = createRPCHandler({
           rpcId,
           rpc,
           store,
           actions,
-          mapStateToParams: (state, args) => mapStateToParams(state, args, this.props),
+          mapStateToParams,
           transformParams,
         });
         const props = {


### PR DESCRIPTION
The current design makes this un-ergonomic for things like grabbing url params from react-router.

This will also open up use cases like calling `connect` first to massage data and then grabbing those props